### PR TITLE
Cover format tweaks

### DIFF
--- a/sphinx_simplepdf/themes/simplepdf_theme/cover.html
+++ b/sphinx_simplepdf/themes/simplepdf_theme/cover.html
@@ -10,7 +10,7 @@
     <div class="cover-middle">
       <div class="title">
         <h1 class="title-cover">{{ project|striptags|e }}</h1>
-        <p class="subtitle-cover">Version {{ version }}</p>
+        <p class="subtitle-cover">{{ version }}</p>
         <span class="meta">
           {{ cover_meta_data }}
         </span>

--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/main.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/main.scss
@@ -82,7 +82,7 @@ html {
     h1 {
       color: $primary;
       font-size: 30pt;
-      page-break-before: always;
+      break-before: avoid-page;
     }
 
     h2, h3, h4 {
@@ -91,7 +91,7 @@ html {
     }
 
     h2 {
-      page-break-before: always;
+      break-before: avoid-page;
       font-size: 28pt;
       string-set: heading content();
     }


### PR DESCRIPTION
Style tweaks to:

- Remove 'Version' text from cover page, so we can leave `conf.version` empty without dangling text on the resulting cover page.
- Set styles to not force a page break before a H1 to get rid of the empty page that gets inserted before the first page of content.
- Set H2 to also not force a page break before for consistency.