### PR TITLE
DEV-5278 general pdf style fixes -- primarily to add and fix fonts + logo

### DIFF
--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_admonition.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_admonition.scss
@@ -4,6 +4,10 @@
     margin-bottom: 24px;
     background: #e7f2fa;
 
+    *>p {
+        margin-bottom: 0;
+    }
+
     .admonition-title {
         color: #fff;
         font-weight: bold;
@@ -18,7 +22,6 @@
             font-family: fontawesome-webfont;
        	    content: "\f06a";
             font-style: normal;
-           	font-weight: normal;
            	line-height: 1;
            	text-decoration: inherit;
             margin-right: 4px;

--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_api.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_api.scss
@@ -23,14 +23,14 @@ dl.head, dl.get, dl.post, dl.put, dl.delete, dl.patch, dl.options, dl.trace, dl.
     > dd {
         margin-left: 0;
 
-        > p > strong {
-            font-weight: normal;
-        }
+        // > p > strong {
+        //     font-weight: normal;
+        // }
     }
 
-    span.sig-paren, em.property, em.sig-param {
-        font-weight: normal;
-    }
+    // span.sig-paren, em.property, em.sig-param {
+    //     font-weight: normal;
+    // }
 
     code.descname:first-child {
         font-size: 0.9em;

--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_code.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_code.scss
@@ -4,7 +4,6 @@ dl.class, dl.type, dl.function, dl.member, dl.var, dl.enum, dl.enum-class, dl.en
     }
 
     > dt {
-        font-weight: normal;
     }
 
     em.property {

--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_cover.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_cover.scss
@@ -12,7 +12,6 @@
     margin: 0;
 
     h1 {
-        font-family: "Work Sans", sans-serif;
         color: $primary;
         font-size: 38pt;
         margin: 5cm 2cm 0 2cm;
@@ -55,7 +54,6 @@
                 height: 150pt;
 
                 .title-cover {
-                    font-family: "Work Sans Bold", sans-serif;
                     font-size: 45pt;
                     margin-bottom: 0;
                     margin-top: 0;
@@ -64,7 +62,6 @@
                 }
 
                 .subtitle-cover {
-                    font-family: "Work Sans Bold", sans-serif;
                     font-weight: bolder;
                     font-size: 28pt;
                     // text-transform: uppercase;
@@ -73,7 +70,6 @@
                 }
 
                 .meta {
-                    font-family: 'Work Sans';
                     font-size: 18pt;
                     margin-top: 12pt;
                     margin-bottom: 0;
@@ -100,7 +96,6 @@
         }
 
         .cover-footer {
-            font-family: 'Work Sans';
             font-size: 11pt;
             margin-top: 3px;
             position: absolute;

--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_fonts.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_fonts.scss
@@ -1,54 +1,4 @@
 @font-face {
-    font-family: Work Sans Bold;
-    font-weight: bold;
-    src: url(fonts/WorkSans-Bold.ttf);
-}
-
-@font-face {
-    font-family: Work Sans Bold;
-    font-weight: 400;
-    src: url(fonts/WorkSans-SemiBold.ttf);
-}
-
-@font-face {
-    font-family: Work Sans;
-    font-weight: 400;
-    src: url(fonts/WorkSans-Regular.ttf);
-}
-
-@font-face {
-    font-family: Fira Sans;
-    font-weight: 400;
-    src: url(fonts/FiraSans-Regular.otf);
-}
-
-@font-face {
-    font-family: Fira Sans;
-    font-style: italic;
-    font-weight: 400;
-    src: url(fonts/FiraSans-Italic.otf);
-}
-
-@font-face {
-    font-family: Fira Sans;
-    font-weight: 300;
-    src: url(fonts/FiraSans-Light.otf);
-}
-
-@font-face {
-    font-family: Fira Sans;
-    font-style: italic;
-    font-weight: 300;
-    src: url(fonts/FiraSans-LightItalic.otf);
-}
-
-@font-face {
-    font-family: Fira Sans;
-    font-weight: bold;
-    src: url(fonts/FiraSans-Bold.otf);
-}
-
-@font-face {
     font-family: fontawesome-webfont;
     //font-weight: normal;
     //font-style: normal;
@@ -57,19 +7,59 @@
  }
 
 @font-face {
-    font-family: monospace;
-    src: url(fonts/FiraMono-Regular.ttf);
+    font-family: 'Gotham';
+    src: url('https://docs.eclecticiq.com/_static/css/Gotham/Gotham-Light.otf') format('opentype');
+    font-weight: 300;
+    font-style: normal;
+    font-display: swap;
 }
-
-
 @font-face {
-    font-family: monospace;
+    font-family: 'Gotham book';
+    src: url('https://docs.eclecticiq.com/_static/css/Gotham/Gotham-Book.otf') format('opentype');
     font-weight: 400;
-    src: url(fonts/FiraMono-Medium.ttf);
+    font-style: normal;
+    font-display: swap;
+}
+@font-face {
+    font-family: 'Gotham';
+    src: url('https://docs.eclecticiq.com/_static/css/Gotham/Gotham-Medium.otf') format('opentype');
+    font-weight: 500;
+    font-style: normal;
+    font-display: swap;
+}
+@font-face {
+    font-family: 'Gotham';
+    src: url('https://docs.eclecticiq.com/_static/css/Gotham/Gotham-Bold.otf') format('opentype');
+    font-weight: 700;
+    font-style: normal;
+    font-display: swap;
+}
+@font-face {
+    font-family: 'Gotham';
+    src: url('https://docs.eclecticiq.com/_static/css/Gotham/Gotham-LightItalic.otf') format('opentype');
+    font-weight: 300;
+    font-style: italic;
+    font-display: swap;
+}
+@font-face {
+    font-family: 'Gotham';
+    src: url('https://docs.eclecticiq.com/_static/css/Gotham/Gotham-BookItalic.otf') format('opentype');
+    font-weight: 400;
+    font-style: italic;
+    font-display: swap;
 }
 
 @font-face {
-    font-family: monospace;
-    font-weight: bold;
-    src: url(fonts/FiraMono-Bold.ttf);
+    font-family: 'Gotham';
+    src: url('https://docs.eclecticiq.com/_static/css/Gotham/Gotham-MediumItalic.otf') format('opentype');
+    font-weight: 500;
+    font-style: italic;
+    font-display: swap;
+}
+@font-face {
+    font-family: 'Gotham';
+    src: url('https://docs.eclecticiq.com/_static/css/Gotham/Gotham-BoldItalic.otf') format('opentype');
+    font-weight: 700;
+    font-style: italic;
+    font-display: swap;
 }

--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_lists.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_lists.scss
@@ -28,7 +28,6 @@ dl.option-list, dl.field-list {
         padding-right: 15px;
         flex: 0 0 33%;
         max-width: 33%;
-        font-weight: normal;
     }
 
     dd {

--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_pages.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_pages.scss
@@ -36,8 +36,8 @@
   padding-top: 1em;
 
   @top-left {
-    background: $primary;
-    color: $white;
+    /* background: $primary;
+    color: $white; */
     content: $top-left-content;
     height: 1cm;
     text-align: center;

--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_tables.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_tables.scss
@@ -38,7 +38,6 @@ table.docutils {
 
             td {
                 display: table-cell;
-                font-weight: normal !important;
             }
             * {
                 border: 0;

--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_text.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_text.scss
@@ -16,7 +16,7 @@
 }
 
 .text-primary {
-    color: #007bff !important;
+    color: #3975B0 !important;
 }
 
 a {
@@ -26,15 +26,15 @@ a {
 }
 
 a.text-primary:hover, a.text-primary:focus {
-    color: #0056b3 !important;
+    color: #1F5991 !important;
 }
 
 .text-secondary {
-    color: #6c757d !important;
+    color: #595959 !important;
 }
 
 a.text-secondary:hover, a.text-secondary:focus {
-    color: #494f54 !important;
+    color: #999999 !important;
 }
 
 .text-success {
@@ -86,7 +86,7 @@ a.text-dark:hover, a.text-dark:focus {
 }
 
 .text-body {
-    color: #212529 !important;
+    color: #262626 !important;
 }
 
 .text-muted {
@@ -166,7 +166,6 @@ a.download {
             font-family: fontawesome-webfont;
        	    content: "\f019";
             font-style: normal;
-           	font-weight: normal;
            	line-height: 1;
            	text-decoration: inherit;
             margin-right: 2px;

--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/main.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/main.scss
@@ -72,47 +72,44 @@ body {
 }
 
 html {
-  color: #393939;
-  font-family: Fira Sans;
-  font-size: 11pt;
+  color: #262626;
+  font-family: "Gotham", "Montserrat", Arial, Helvetica, sans-serif;
+  font-size: 10pt;
   font-weight: 300;
-  line-height: 1.5;
+  line-height: 1.333rem;
 
   body {
-    h1 {
-      color: $primary;
-      font-size: 30pt;
-      break-before: avoid-page;
+    h1, h2, h3, h4, h5, h6 {
+      color: #262626;
+      font-weight: 700;
+      line-height: 100%;
     }
 
-    h2, h3, h4 {
-      color: black;
-      font-weight: 400;
+    h1 {
+      font-size: 2.25rem;
+      break-before: avoid-page;
     }
 
     h2 {
       break-before: avoid-page;
-      font-size: 28pt;
+      font-size: 2rem;
       string-set: heading content();
     }
 
     h3 {
-      font-weight: 300;
-      font-size: 20pt;
+      font-size: 1.625rem;
     }
 
     h4 {
-      font-size: 16pt;
+      font-size: 1.3125rem;
     }
 
     h5 {
-      font-size: 15pt;
-      font-weight: 100;
+      font-size: 1.125rem;
     }
 
     h6 {
-      font-size: 13pt;
-      font-weight: 100;
+      font-size: 1rem;
 
     }
 


### PR DESCRIPTION
- add gotham font -- primarily to fix fonts in logo svg for now
- remove black box from top-left style -- this was just getting in the
  way of logo images.
- implement font fixes
- make cover styles use body text font
- remove extranous spacing in lists in admonitions